### PR TITLE
Add gmail signature detection by presence of gmail_signature class

### DIFF
--- a/src/common/markdown-here.js
+++ b/src/common/markdown-here.js
@@ -155,16 +155,21 @@ function getOperationalRange(focusedElem) {
 // exclusion code. But I'm not sure how to find the sig as well without being
 // able to traverse the DOM. (Surely with regexes and parsing... someday.)
 function findSignatureStart(startElem) {
-  var i, child, recurseReturn, sig;
+  var i, child, recurseReturn, sig, gmailSig;
 
   sig = null;
+  
+  // All Gmail sigs are given "gmail_signature" class - check for this first
+  gmailSig = startElem.getElementsByClassName('gmail_signature');
+  if(gmailSig.length === 1)
+    return gmailSig[0];
 
   for (i = 0; i < startElem.childNodes.length; i++) {
     child = startElem.childNodes[i];
     if (child.nodeType === child.TEXT_NODE) {
       // Thunderbird wraps the sig in a `<pre>`, so there's a newline.
       // Hand-written sigs (including Hotmail and Yahoo) are `'--&nbsp;'` (aka \u00a0).
-      // Gmail auto-inserted sigs are `'-- '` (plain space).
+      // Gmail auto-inserted sigs are `'-- '` (plain space)
       if (child.nodeValue.search(/^--[\s\u00a0]+(\n|$)/) === 0) {
 
         // Assume that the entire parent element belongs to the sig only if the


### PR DESCRIPTION
This (tiny) PR addresses #219, however whether you merge is at your discretion because of the behaviour I noticed when testing:

- When composing a new mail in gmail, the signature is inserted within a DOM element that has the `gmail_signature` class. The couple of lines I've added will detect the signature & skip the DOM recursion.
- After saving the mail as a draft and closing your browser tab, all of the classes on the email's markup are lost. As such, **when returning to an old draft from a previous browsing session, this method of signature detection fails**.

I'm therefore in two minds as to whether this would be a beneficial thing; on the one hand, custom gmail signatures that weren't currently working will work without the need to prefix with `-- `, but on the other, users may experience this sort of signature being parsed as markdown intermittently, which might be more confusing than the previous consistent inclusion.

