### PR TITLE
Forgot-to-Render check for Fastmail

### DIFF
--- a/contributors/michaelstepner.md
+++ b/contributors/michaelstepner.md
@@ -1,0 +1,9 @@
+2015-12-01
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor Assignment Agreement", with MD5 checksum 20a56153709a38a23316feb565f80756.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Michael Stepner https://github.com/michaelstepner

--- a/src/common/common-logic.js
+++ b/src/common/common-logic.js
@@ -131,6 +131,9 @@ function getForgotToRenderButtonSelector(elem) {
   else if (elem.ownerDocument.location.host.indexOf('inbox.google.') >= 0) {
     return '[role="button"][tabindex="0"][jsaction$=".send"]';
   }
+  else if (elem.ownerDocument.location.host.indexOf('fastmail.') >= 0) {
+    return '[class~="s-send"]';
+  }
 
   return null;
 }

--- a/src/common/forgot-to-render-prompt.html
+++ b/src/common/forgot-to-render-prompt.html
@@ -107,6 +107,7 @@
     padding-bottom: 0.3em;
     margin-top: 1.5em;
     width: 5em;
+    text-align: center;
   }
 </style>
 


### PR DESCRIPTION
Hi Adam,

I was tired of forgetting to render my Markdown emails in Fastmail, and decided to see if I could extend your excellent forgot-to-render check to the Fastmail compose interface. (Issue #317)

It almost-but-not-quite works in this initial PR.  The event listeners are set up and work properly, both for clicking the **Send** button and for using the send hotkeys (which are the same in Fastmail as Gmail).  The script correctly catches and prevents sending an unrendered email when I click **Send**.  But if I use the ⌘+Enter hotkey, the email is sent _and then_ Markdown Here opens the forgot to render prompt.  It seems that `eatEvent()` is not eating the hotkey send action.

I have no prior experience with JavaScript, so I thought I would stop here and ask you for guidance.  In fact, this is also my first submission to an open source project.

Michael
