### PR TITLE
Issue 258 - Added Google Chrome Badge 

### DIFF
--- a/contributors/dchanman.md
+++ b/contributors/dchanman.md
@@ -1,0 +1,9 @@
+2015-11-22
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor License Agreement", with MD5 checksum 20a56153709a38a23316feb565f80756.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Derek Chan https://github.com/dchanman

--- a/contributors/kenken28.md
+++ b/contributors/kenken28.md
@@ -1,0 +1,9 @@
+2015-12-01
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor License Agreement", with MD5 checksum 20a56153709a38a23316feb565f80756.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Yuxin Xu https://github.com/kenken28

--- a/src/chrome/backgroundscript.js
+++ b/src/chrome/backgroundscript.js
@@ -115,6 +115,15 @@ chrome.extension.onMessage.addListener(function(request, sender, responseCallbac
       return false;
     }
   }
+  else if (request.action === 'show-toggle-button-badge') {
+    if (request.show) {
+      chrome.browserAction.setBadgeText({text: "R", tabId: sender.tab.id});
+      chrome.browserAction.setBadgeBackgroundColor({color: "#7a1ea1", tabId: sender.tab.id});
+    }
+    else {
+      chrome.browserAction.setBadgeText({text: "", tabId: sender.tab.id});
+    }
+  }
   else if (request.action === 'upgrade-notification-shown') {
     clearUpgradeNotification();
     return false;

--- a/src/chrome/contentscript.js
+++ b/src/chrome/contentscript.js
@@ -159,16 +159,31 @@ function setToggleButtonVisibility(elem) {
   }
 }
 
+var setToggleButtonBadgePrefs = null;
 function setToggleButtonBadge(elem) {
   var showBadge = false;
 
-  // The badge indicates the to user that s/he has UNRENDERED markdown
+  if (!setToggleButtonBadgePrefs) {
+      Utils.makeRequestToPrivilegedScript(
+        document,
+        { action: 'get-options' },
+        function(prefs) {
+          setToggleButtonBadgePrefs = prefs;
+        });
 
-  // We don't want to show the badge if the selection is unrenderable
-  if (lastRenderable) {
-    if (elem && elem.ownerDocument) {
-      // We don't want to show the badge if the selection contains rendered text
-      showBadge = !(markdownHere.selectionContainsRenderedMarkdown(elem.ownerDocument));
+  } else {
+
+    if (setToggleButtonBadgePrefs['google-chrome-badge-enabled']) {
+
+      // The badge indicates the to user that s/he has UNRENDERED markdown
+
+      // We don't want to show the badge if the selection is unrenderable
+      if (lastRenderable) {
+        if (elem && elem.ownerDocument) {
+          // We don't want to show the badge if the selection contains rendered text
+          showBadge = !(markdownHere.selectionContainsRenderedMarkdown(elem.ownerDocument));
+        }
+      }
     }
   }
 

--- a/src/common/markdown-here.js
+++ b/src/common/markdown-here.js
@@ -577,6 +577,30 @@ function getMarkdownRenderObject(document) {
 }
 
 // Exported function.
+// Determines if the current selection will be unrendered by the markdownHere()
+// function (@see markdownHere)
+// @param `document`  The document object containing the email compose element.
+//        (Actually, it can be any document above the compose element. We'll
+//        drill down to find the correct element and document.)
+// @returns True if selection is inside a Markdown wrapper or contains wrappers
+function selectionContainsRenderedMarkdown(document) {
+
+  var renderObj, wrappers;
+
+  renderObj = getMarkdownRenderObject(document);
+  if (typeof(renderObj) !== 'object') {
+    return false;
+  }
+
+  wrappers = renderObj.wrappers;
+  if (wrappers && wrappers.length > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// Exported function.
 // The context menu handler. Does the rendering or unrendering, depending on the
 // state of the email compose element and the current selection.
 // @param `document`  The document object containing the email compose element.
@@ -670,6 +694,7 @@ function markdownHere(document, markdownRenderer, logger, renderComplete) {
 // We also export a couple of utility functions
 markdownHere.findFocusedElem = findFocusedElem;
 markdownHere.elementCanBeRendered = elementCanBeRendered;
+markdownHere.selectionContainsRenderedMarkdown = selectionContainsRenderedMarkdown;
 
 var EXPORTED_SYMBOLS = ['markdownHere'];
 

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -634,6 +634,14 @@ MIT License : http://adampritchard.mit-license.org/
           </label>
         </div>
         <hr/>
+        <div>
+          <input type="checkbox" id="google-chrome-badge-enabled"/>
+          <!--TODO: Add translation for google-chrome-badge_label -->
+          <label for="google-chrome-badge-enabled">
+            <b>Enable Google Chrome render notification badge.</b>
+          </label>
+        </div>
+        <hr/>
       </div>
 
       <div class="control-group">

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -16,6 +16,7 @@
 var cssEdit, cssSyntaxEdit, cssSyntaxSelect, rawMarkdownIframe, savedMsg,
     mathEnable, mathEdit, hotkeyShift, hotkeyCtrl, hotkeyAlt, hotkeyKey,
     forgotToRenderCheckEnabled, headerAnchorsEnabled, gfmLineBreaksEnabled,
+    googleChromeBadgeEnabled,
     loaded = false;
 
 function onLoad() {
@@ -41,6 +42,7 @@ function onLoad() {
   forgotToRenderCheckEnabled = document.getElementById('forgot-to-render-check-enabled');
   headerAnchorsEnabled = document.getElementById('header-anchors-enabled');
   gfmLineBreaksEnabled = document.getElementById('gfm-line-breaks-enabled');
+  googleChromeBadgeEnabled = document.getElementById('google-chrome-badge-enabled');
 
   //
   // Syntax highlighting styles and selection
@@ -90,6 +92,8 @@ function onLoad() {
     headerAnchorsEnabled.checked = prefs['header-anchors-enabled'];
 
     gfmLineBreaksEnabled.checked = prefs['gfm-line-breaks-enabled'];
+
+    googleChromeBadgeEnabled.checked = prefs['google-chrome-badge-enabled'];
 
     // Start watching for changes to the styles.
     setInterval(checkChange, 100);
@@ -209,7 +213,7 @@ function checkChange() {
         mathEnable.checked + mathEdit.value +
         hotkeyShift.checked + hotkeyCtrl.checked + hotkeyAlt.checked + hotkeyKey.value +
         forgotToRenderCheckEnabled.checked + headerAnchorsEnabled.checked +
-        gfmLineBreaksEnabled.checked;
+        gfmLineBreaksEnabled.checked + googleChromeBadgeEnabled.checked;
 
   if (newOptions !== lastOptions) {
     // CSS has changed.
@@ -240,7 +244,8 @@ function checkChange() {
                     },
           'forgot-to-render-check-enabled': forgotToRenderCheckEnabled.checked,
           'header-anchors-enabled': headerAnchorsEnabled.checked,
-          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked
+          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked,
+          'google-chrome-badge-enabled': googleChromeBadgeEnabled.checked
         },
         function() {
           updateMarkdownRender();

--- a/src/common/test/markdown-here-test.js
+++ b/src/common/test/markdown-here-test.js
@@ -112,5 +112,57 @@ describe('markdownHere', function() {
       });
     });
 
+    describe('selectionContainsRenderedMarkdown', function() {
+
+      it('should detect rendered markdown', function(done) {
+        var md = '_some markdown_';
+
+        // First render
+        renderMD(md, function(elem) {
+          // Then check if we detect it
+          $testElem.focus();
+          expect(markdownHere.selectionContainsRenderedMarkdown(document)).to.equal(true);
+          done();
+        });
+      });
+
+      it('should not detect unrendered markdown', function(done) {
+        var md = '_some markdown_';
+        $testElem.html(md);
+        expect(markdownHere.selectionContainsRenderedMarkdown(document)).to.equal(false);
+        done();
+      });
+
+      it('should not detect rendered markdown in empty document', function(done) {
+        expect(markdownHere.selectionContainsRenderedMarkdown(document)).to.equal(false);
+        done();
+      });
+
+      it('should return an error when there is no focussed element', function(done) {
+        var fakeDocument = '**This is a fakeDocument**';
+        renderMD(function(elem) {
+          expect(markdownHere.selectionContainsRenderedMarkdown(fakeDocument)).to.equal(false);
+          done();
+        });
+      });
+
+      it('should not detect rendered markdown if the rendered markdown is not selected', function(done) {
+        var md = '_some markdown_';
+        var myText = document.createElement('textarea');
+        document.body.appendChild(myText);
+        myText.value = '_some more markdown_';
+
+        // First render
+        renderMD(md, function(elem) {
+          // Then focus on another place and check if we detect the rendered markdown
+          myText.focus();
+          expect(markdownHere.selectionContainsRenderedMarkdown(document)).to.equal(false);
+          done();
+        });
+
+        myText.remove();
+      });
+
+    });
   });
 });


### PR DESCRIPTION
Hi Adam,

This pull request adds a Google Chrome badge to indicate to the user whether their selection will be rendered or unrendered. This was mentioned in Issue #258 (Make toggle button more state-aware).

There was an earlier pull request that had messy commits (PR #315 ). This contains the same content but tidier.

Here's a snippet of the badge:

![](https://cloud.githubusercontent.com/assets/5429930/11435643/78848f84-9491-11e5-8c2e-94cdfbfd8f62.png)
## Refactor changes

In the `markdown-here.js` file, we pulled out some code inside `markdownHere` and put it into a new function `getMarkdownRenderObject` so that we could reuse it. You'll see there's a another new function called `selectionContainsRenderedMarkdown` that needed the same code.
