### PR TITLE
add option to force insert line breaks to highlighting code.

### DIFF
--- a/src/common/markdown-render.js
+++ b/src/common/markdown-render.js
@@ -85,6 +85,7 @@ function markdownRender(mdText, userprefs, marked, hljs) {
     // so we'll add it by sneaking it into this config field.
     langPrefix: 'hljs language-',
     math: userprefs['math-enabled'] ? mathify : null,
+    highlightForceBreaks: userprefs['highlight-line-breaks-enabled'],
     highlight: function(codeText, codeLanguage) {
         if (codeLanguage &&
             hljs.getLanguage(codeLanguage.toLowerCase())) {

--- a/src/common/marked.js
+++ b/src/common/marked.js
@@ -778,6 +778,9 @@ Renderer.prototype.code = function(code, lang, escaped) {
     var out = this.options.highlight(code, lang);
     if (out != null && out !== code) {
       escaped = true;
+      if (this.options.highlightForceBreaks) {
+         out = out.replace(/\n/g, '<br>');
+      }
       code = out;
     }
   }
@@ -1248,6 +1251,7 @@ marked.defaults = {
   smartLists: false,
   silent: false,
   highlight: null,
+  highlightForceBreaks: false,
   langPrefix: 'lang-',
   smartypants: false,
   headerPrefix: '',

--- a/src/common/options-store.js
+++ b/src/common/options-store.js
@@ -22,7 +22,8 @@ var DEFAULTS = {
   'hotkey': { shiftKey: false, ctrlKey: true, altKey: true, key: 'M' },
   'forgot-to-render-check-enabled': false,
   'header-anchors-enabled': false,
-  'gfm-line-breaks-enabled': true
+  'gfm-line-breaks-enabled': true,
+  'highlight-line-breaks-enabled': false 
 };
 
 /*? if(platform!=='mozilla'){ */
@@ -129,6 +130,7 @@ var ChromeOptionsStore = {
     'hotkey': DEFAULTS['hotkey'],
     'forgot-to-render-check-enabled': DEFAULTS['forgot-to-render-check-enabled'],
     'header-anchors-enabled': DEFAULTS['header-anchors-enabled'],
+    'highlight-line-breaks-enabled': DEFAULTS['highlight-line-breaks-enabled'],
     'gfm-line-breaks-enabled': DEFAULTS['gfm-line-breaks-enabled']
   },
 
@@ -293,6 +295,7 @@ var MozillaOptionsStore = {
     'hotkey': DEFAULTS['hotkey'],
     'forgot-to-render-check-enabled': DEFAULTS['forgot-to-render-check-enabled'],
     'header-anchors-enabled': DEFAULTS['header-anchors-enabled'],
+    'highlight-line-breaks-enabled': DEFAULTS['highlight-line-breaks-enabled'],
     'gfm-line-breaks-enabled': DEFAULTS['gfm-line-breaks-enabled']
   },
 
@@ -481,6 +484,7 @@ var SafariOptionsStore = {
     'hotkey': DEFAULTS['hotkey'],
     'forgot-to-render-check-enabled': DEFAULTS['forgot-to-render-check-enabled'],
     'header-anchors-enabled': DEFAULTS['header-anchors-enabled'],
+    'highlight-line-breaks-enabled': DEFAULTS['highlight-line-breaks-enabled'],
     'gfm-line-breaks-enabled': DEFAULTS['gfm-line-breaks-enabled']
   }
 };

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -634,6 +634,18 @@ MIT License : http://adampritchard.mit-license.org/
           </label>
         </div>
         <hr/>
+        <div>
+          <input type="checkbox" id="highlight-line-breaks-enabled"/>
+          <label for="highlight-line-breaks-enabled" data-i18n="highlight_line_breaks_enabled_label">
+            <b>Enable line breaks in Syntax Highlighting.</b>
+          </label>
+          <div class="extra-description">
+            <p data-i18n="highlight_line_breaks_enabled_1">
+              try to add line breaks &lt;br&gt; when in some case CSS "white-space:pre" not work.
+            </p>
+         </div>
+        </div>
+        <hr/>
       </div>
 
       <div class="control-group">

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -16,6 +16,7 @@
 var cssEdit, cssSyntaxEdit, cssSyntaxSelect, rawMarkdownIframe, savedMsg,
     mathEnable, mathEdit, hotkeyShift, hotkeyCtrl, hotkeyAlt, hotkeyKey,
     forgotToRenderCheckEnabled, headerAnchorsEnabled, gfmLineBreaksEnabled,
+    highlightLineBreaksEnabled,
     loaded = false;
 
 function onLoad() {
@@ -41,6 +42,7 @@ function onLoad() {
   forgotToRenderCheckEnabled = document.getElementById('forgot-to-render-check-enabled');
   headerAnchorsEnabled = document.getElementById('header-anchors-enabled');
   gfmLineBreaksEnabled = document.getElementById('gfm-line-breaks-enabled');
+  highlightLineBreaksEnabled = document.getElementById('highlight-line-breaks-enabled');
 
   //
   // Syntax highlighting styles and selection
@@ -90,6 +92,8 @@ function onLoad() {
     headerAnchorsEnabled.checked = prefs['header-anchors-enabled'];
 
     gfmLineBreaksEnabled.checked = prefs['gfm-line-breaks-enabled'];
+
+    highlightLineBreaksEnabled.checked = prefs['highlight-line-breaks-enabled'];
 
     // Start watching for changes to the styles.
     setInterval(checkChange, 100);
@@ -209,7 +213,7 @@ function checkChange() {
         mathEnable.checked + mathEdit.value +
         hotkeyShift.checked + hotkeyCtrl.checked + hotkeyAlt.checked + hotkeyKey.value +
         forgotToRenderCheckEnabled.checked + headerAnchorsEnabled.checked +
-        gfmLineBreaksEnabled.checked;
+        gfmLineBreaksEnabled.checked + highlightLineBreaksEnabled.checked;
 
   if (newOptions !== lastOptions) {
     // CSS has changed.
@@ -240,7 +244,8 @@ function checkChange() {
                     },
           'forgot-to-render-check-enabled': forgotToRenderCheckEnabled.checked,
           'header-anchors-enabled': headerAnchorsEnabled.checked,
-          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked
+          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked,
+          'highlight-line-breaks-enabled': highlightLineBreaksEnabled.checked
         },
         function() {
           updateMarkdownRender();


### PR DESCRIPTION
<img width="655" alt="option_highlight_line_break" src="https://cloud.githubusercontent.com/assets/1134993/12893344/88a8fad4-cecb-11e5-80f5-8fe1795a3e21.png">

> Add a option which allow force insert &lt;br&gt; into the &lt;pre&gt; of the syntax highlighting code in the case when CSS "write-space:pre" not work. The option is off by default.

<img width="574" alt="screen shot 2016-02-09 at 1 30 45 am" src="https://cloud.githubusercontent.com/assets/1134993/12893595/f410181a-cecc-11e5-8670-dae08c198f25.png">

> enable the option, let the line breaks work in the case.
 
<img width="523" alt="after_hightlight_break" src="https://cloud.githubusercontent.com/assets/1134993/12893572/d721c2c6-cecc-11e5-95dc-bd2ced672db7.png">

