### PR TITLE
Support Evernote task lists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Thumbs.db
 
 # Build directory
 dist
+
+# JetBrains WebStorm
+.idea

--- a/contributors/makethemo.md
+++ b/contributors/makethemo.md
@@ -1,0 +1,9 @@
+2017-11-12
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor License Agreement", with MD5 checksum 6a31e08cf66139e91c0db5599b6ab084.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Jinseop Mo https://github.com/makethemo

--- a/src/common/markdown-render.js
+++ b/src/common/markdown-render.js
@@ -72,6 +72,25 @@ function markdownRender(mdText, userprefs, marked, hljs) {
     return defaultLinkRenderer.call(this, href, title, text);
   };
 
+  var defaultLinkRenderer = markedRenderer.listitem;
+  markedRenderer.listitem = function(text) {
+      if (userprefs['evernote-task-lists-enabled']) {
+        if (/^\s*\[[x ]\]\s*/.test(text)) {
+          var todoImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+          text = text
+              .replace(/^\s*\[ \]\s*/, '<img class="en-todo" src="' + todoImg + '"> ')
+              .replace(/^\s*\[x\]\s*/, '<img class="en-todo en-todo-checked" src="' + todoImg + '"> ');
+          return '<li style="list-style: none">' + text + '</li>';
+        }
+        else {
+          return '<li>' + text + '</li>';
+        }
+      }
+      else {
+        return defaultLinkRenderer.call(this, text);
+      }
+  };
+
   var markedOptions = {
     renderer: markedRenderer,
     gfm: true,

--- a/src/common/markdown-render.js
+++ b/src/common/markdown-render.js
@@ -72,19 +72,17 @@ function markdownRender(mdText, userprefs, marked, hljs) {
     return defaultLinkRenderer.call(this, href, title, text);
   };
 
-  var defaultLinkRenderer = markedRenderer.list;
+  var defaultListRenderer = markedRenderer.list;
   markedRenderer.list = function(body, ordered) {
-    if (userprefs['evernote-task-lists-enabled'] && location.href.match(/evernote.com/)
-        && !ordered && /<.*en-todo.*>/.test(body)) {
+    if (userprefs['evernote-task-lists-enabled'] && /<.*en-todo.*>/.test(body)) {
       return '<div>' + body + '</div>\n';
     }
-    return defaultLinkRenderer.call(this, body, ordered);
+    return defaultListRenderer.call(this, body, ordered);
   };
 
-  var defaultLinkRenderer = markedRenderer.listitem;
+  var defaultListItemRenderer = markedRenderer.listitem;
   markedRenderer.listitem = function(text) {
-    if (userprefs['evernote-task-lists-enabled'] && location.href.match(/evernote.com/)
-        && /\s*\[[x ]\]\s*/.test(text)) {
+    if (userprefs['evernote-task-lists-enabled'] && /\s*\[[x ]\]\s*/.test(text)) {
       var todoImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
       text = text
           .replace(/\s*\[ \]\s*/g, '<img class="en-todo" src="' + todoImg + '"> ')
@@ -92,7 +90,7 @@ function markdownRender(mdText, userprefs, marked, hljs) {
       return '<div>' + text + '</div>\n';
     }
     else {
-      return defaultLinkRenderer.call(this, text);
+      return defaultListItemRenderer.call(this, text);
     }
   };
 

--- a/src/common/markdown-render.js
+++ b/src/common/markdown-render.js
@@ -74,7 +74,7 @@ function markdownRender(mdText, userprefs, marked, hljs) {
 
   var defaultLinkRenderer = markedRenderer.listitem;
   markedRenderer.listitem = function(text) {
-      if (userprefs['evernote-task-lists-enabled']) {
+      if (userprefs['evernote-task-lists-enabled'] && location.href.match('evernote.com')) {
         if (/^\s*\[[x ]\]\s*/.test(text)) {
           var todoImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
           text = text

--- a/src/common/markdown-render.js
+++ b/src/common/markdown-render.js
@@ -72,23 +72,28 @@ function markdownRender(mdText, userprefs, marked, hljs) {
     return defaultLinkRenderer.call(this, href, title, text);
   };
 
+  var defaultLinkRenderer = markedRenderer.list;
+  markedRenderer.list = function(body, ordered) {
+    if (userprefs['evernote-task-lists-enabled'] && location.href.match(/evernote.com/)
+        && !ordered && /<.*en-todo.*>/.test(body)) {
+      return '<div>' + body + '</div>\n';
+    }
+    return defaultLinkRenderer.call(this, body, ordered);
+  };
+
   var defaultLinkRenderer = markedRenderer.listitem;
   markedRenderer.listitem = function(text) {
-      if (userprefs['evernote-task-lists-enabled'] && location.href.match('evernote.com')) {
-        if (/^\s*\[[x ]\]\s*/.test(text)) {
-          var todoImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-          text = text
-              .replace(/^\s*\[ \]\s*/, '<img class="en-todo" src="' + todoImg + '"> ')
-              .replace(/^\s*\[x\]\s*/, '<img class="en-todo en-todo-checked" src="' + todoImg + '"> ');
-          return '<li style="list-style: none">' + text + '</li>';
-        }
-        else {
-          return '<li>' + text + '</li>';
-        }
-      }
-      else {
-        return defaultLinkRenderer.call(this, text);
-      }
+    if (userprefs['evernote-task-lists-enabled'] && location.href.match(/evernote.com/)
+        && /\s*\[[x ]\]\s*/.test(text)) {
+      var todoImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+      text = text
+          .replace(/\s*\[ \]\s*/g, '<img class="en-todo" src="' + todoImg + '"> ')
+          .replace(/\s*\[x\]\s*/g, '<img class="en-todo en-todo-checked" src="' + todoImg + '"> ');
+      return '<div>' + text + '</div>\n';
+    }
+    else {
+      return defaultLinkRenderer.call(this, text);
+    }
   };
 
   var markedOptions = {

--- a/src/common/mdh-html-to-text.js
+++ b/src/common/mdh-html-to-text.js
@@ -111,6 +111,15 @@ MdhHtmlToText.prototype._preprocess = function() {
                           /&lt;<a (href="mailto:[^>]+)>([^<]*)<\/a>&gt;/ig,
                           '&lt;&lt;a $1&gt;$2&lt;\/a&gt;&gt;');
 
+  // Support Evernote task lists.
+  // This code must be executed before handling <img>.
+  if (location.href.match(/evernote.com/)) {
+      this.preprocessInfo.html =
+        this.preprocessInfo.html
+          .replace(/<.*en-todo-checked.*>/ig, '- [x]')
+          .replace(/<.*en-todo.*>/ig, '- [ ]');
+  }
+
   // It's a deviation from Markdown, but we'd like to leave any rendered
   // images already in the email intact. So we'll escape their tags.
   // Note that we can't use excludeTagBlocks because there's no closing tag.

--- a/src/common/mdh-html-to-text.js
+++ b/src/common/mdh-html-to-text.js
@@ -113,12 +113,8 @@ MdhHtmlToText.prototype._preprocess = function() {
 
   // Support Evernote task lists.
   // This code must be executed before handling <img>.
-  if (location.href.match(/evernote.com/)) {
-      this.preprocessInfo.html =
-        this.preprocessInfo.html
-          .replace(/<.*en-todo-checked.*>/ig, '- [x]')
-          .replace(/<.*en-todo.*>/ig, '- [ ]');
-  }
+  this.preprocessInfo.html = this.preprocessInfo.html.replace(/<.*en-todo-checked.*>/ig, '- [x]')
+                                                     .replace(/<.*en-todo.*>/ig, '- [ ]');
 
   // It's a deviation from Markdown, but we'd like to leave any rendered
   // images already in the email intact. So we'll escape their tags.

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -634,6 +634,13 @@ MIT License : http://adampritchard.mit-license.org/
           </label>
         </div>
         <hr/>
+        <div>
+          <input type="checkbox" id="evernote-task-lists-enabled"/>
+          <label for="evernote-task-lists-enabled" data-i18n="evernote_task_lists_enabled_label">
+            <b>Enable Evernote task lists.</b>
+          </label>
+        </div>
+        <hr/>
       </div>
 
       <div class="control-group">

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -16,7 +16,7 @@
 var cssEdit, cssSyntaxEdit, cssSyntaxSelect, rawMarkdownIframe, savedMsg,
     mathEnable, mathEdit, hotkeyShift, hotkeyCtrl, hotkeyAlt, hotkeyKey,
     forgotToRenderCheckEnabled, headerAnchorsEnabled, gfmLineBreaksEnabled,
-    loaded = false;
+    evernoteTaskListsEnabled, loaded = false;
 
 function onLoad() {
   var xhr;
@@ -41,6 +41,7 @@ function onLoad() {
   forgotToRenderCheckEnabled = document.getElementById('forgot-to-render-check-enabled');
   headerAnchorsEnabled = document.getElementById('header-anchors-enabled');
   gfmLineBreaksEnabled = document.getElementById('gfm-line-breaks-enabled');
+  evernoteTaskListsEnabled = document.getElementById('evernote-task-lists-enabled');
 
   //
   // Syntax highlighting styles and selection
@@ -90,6 +91,8 @@ function onLoad() {
     headerAnchorsEnabled.checked = prefs['header-anchors-enabled'];
 
     gfmLineBreaksEnabled.checked = prefs['gfm-line-breaks-enabled'];
+
+    evernoteTaskListsEnabled.checked = prefs['evernote-task-lists-enabled'];
 
     // Start watching for changes to the styles.
     setInterval(checkChange, 100);
@@ -215,7 +218,7 @@ function checkChange() {
         mathEnable.checked + mathEdit.value +
         hotkeyShift.checked + hotkeyCtrl.checked + hotkeyAlt.checked + hotkeyKey.value +
         forgotToRenderCheckEnabled.checked + headerAnchorsEnabled.checked +
-        gfmLineBreaksEnabled.checked;
+        gfmLineBreaksEnabled.checked + evernoteTaskListsEnabled.checked;
 
   if (newOptions !== lastOptions) {
     // CSS has changed.
@@ -246,7 +249,8 @@ function checkChange() {
                     },
           'forgot-to-render-check-enabled': forgotToRenderCheckEnabled.checked,
           'header-anchors-enabled': headerAnchorsEnabled.checked,
-          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked
+          'gfm-line-breaks-enabled': gfmLineBreaksEnabled.checked,
+          'evernote-task-lists-enabled' : evernoteTaskListsEnabled.checked
         },
         function() {
           updateMarkdownRender();


### PR DESCRIPTION
This feature is only available for Evernote. Now we can create Evernote task lists with the GFM-style checkbox. It also supports saving checkbox state. To selectively apply this feature, I added the code for Options.


**GFM-style checkbox:**
```markdown
- [ ] have to do
- [x] something
```


**Evernote task lists:**
![evernote_todo](https://user-images.githubusercontent.com/33351125/32691863-a9389298-c751-11e7-9e1e-b180fe8c1d1c.PNG)


Evernote task lists are represented by the following code:
```html
<div>
  <div>
    <img class="en-todo" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"> have to do
  </div>
  <div>
    <img class="en-todo en-todo-checked" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"> something
  </div>
</div>
```
