### PR TITLE
Fix transparent options dialogue in Thunderbird 60

### DIFF
--- a/src/firefox/chrome/content/options.xul
+++ b/src/firefox/chrome/content/options.xul
@@ -2,6 +2,7 @@
 <!DOCTYPE overlay SYSTEM "chrome://markdown_here/locale/strings.dtd">
 
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://messenger/skin/preferences/preferences.css" type="text/css"?>
 
 <prefwindow id="markdown-here-options-intermediate"
      title="&moz_options_dlg_title;"


### PR DESCRIPTION
In Thunderbird 60 the options dialogue shows transparent. 

Copied this stylesheet reference from the Awesome auto archive project: `CSS for the preference dialogs has moved from Mozilla core to Thunderbird in TB59`