### PR TITLE
Remove need for all-urls permission by using activeTab.

### DIFF
--- a/contributors/dcoles.md
+++ b/contributors/dcoles.md
@@ -1,0 +1,11 @@
+2018-11-13
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor License
+Agreement", with MD5 checksum 6a31e08cf66139e91c0db5599b6ab084.
+
+I furthermore declare that I am authorized and able to make this agreement and
+sign this declaration.
+
+Signed,
+
+David Coles https://github.com/dcoles

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,22 +12,8 @@
     "128": "common/images/icon128.png",
     "512": "common/images/icon512.png"
   },
-  "permissions": ["contextMenus", "storage"],
+  "permissions": ["contextMenus", "storage", "activeTab"],
   "background": {"page": "chrome/background.html"},
-  "content_scripts": [
-    {
-      "matches": ["http://*/*", "https://*/*"],
-      "js": [
-        "common/utils.js",
-        "common/common-logic.js",
-        "common/jsHtmlToText.js",
-        "common/marked.js",
-        "common/mdh-html-to-text.js",
-        "common/markdown-here.js",
-        "chrome/contentscript.js"
-        ]
-    }
-  ],
   "browser_action": {
     "default_icon": {
       "16": "common/images/icon16-button-monochrome.png",


### PR DESCRIPTION
Using a content_type match against http://*/* and https://*/* grants the
extension unfettered access to all data and all browsing activity on all
sites. It also triggers a scary warning during installation.

Using activeTab permission removes the need for continuous access to all
sites by only injecting content scripts upon user interaction.

To ensure that scripts aren't loaded multiple times, the
`markdown_here_loaded` attribute is set on the document on first load.