### PR TITLE
Support cross-extension messaging

### DIFF
--- a/src/chrome/backgroundscript.js
+++ b/src/chrome/backgroundscript.js
@@ -147,6 +147,15 @@ chrome.runtime.onMessage.addListener(function(request, sender, responseCallback)
   }
 });
 
+// Add listener for cros-extension messaging. (See https://developer.chrome.com/extensions/messaging#external)
+chrome.runtime.onMessageExternal.addListener(function(request) {
+  if (request && request.action === 'toggle-markdown') {
+    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+      var tab = tabs[0];
+      chrome.tabs.sendMessage(tab.id, {action: 'button-click', });
+    });
+  }
+});
 // Add the browserAction (the button in the browser toolbar) listener.
 chrome.browserAction.onClicked.addListener(function(tab) {
   chrome.tabs.sendMessage(tab.id, {action: 'button-click', });


### PR DESCRIPTION
This enables other extensions to invoke markdown rendering through:
```js
chrome.runtime.sendMessage(MARKDOWN_HERE_ID, { action: 'toggle-markdown' });
```
It is especially useful when combined with [https://chrome.google.com/webstore/detail/commander/bcjcolkhdoiogoclgfaoihpaininobdj))