### PR TITLE
Fix French translation "traducation" → "traduction"

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -299,7 +299,7 @@
     "message":"<strong>Si vous avez déjà mis un bloc de code dans un courriel, vous pouvez aider à améliorer Markdown Here.<\/strong> <a href=\"https:\/\/github.com\/adam-p\/markdown-here\/blob\/master\/CONTRIBUTING.md\" target=\"_blank\"> CONTRIBUTING.md<\/a>"
   },
   "options_page__contributing_2":{
-    "message":"Aidez à rendre Markdown Here disponible dans votre langue. <a href=\"https:\/\/github.com\/adam-p\/markdown-here\/blob\/master\/CONTRIBUTING.md#translation\" target=\"_blank\">Les traducations sont les bienvenues.<\/a>"
+    "message":"Aidez à rendre Markdown Here disponible dans votre langue. <a href=\"https:\/\/github.com\/adam-p\/markdown-here\/blob\/master\/CONTRIBUTING.md#translation\" target=\"_blank\">Les traductions sont les bienvenues.<\/a>"
   },
   "options_page__footer_1":{
     "message":"<em>Markdown Here<\/em> est open source. Pour poser des questions, signaler un problème, proposer des fonctionnalités ou pour contribuer, visitez la <a target=\"_blank\" href=\"https:\/\/github.com\/adam-p\/markdown-here\">page Github du projet (en anglais)<\/a> ou le <a target=\"_blank\" href=\"https:\/\/groups.google.com\/forum\/?fromgroups=#!forum\/markdown-here\">Groupe Google « markdown-here » (en anglais)<\/a>.",

--- a/src/firefox/chrome/locale/fr/strings.properties
+++ b/src/firefox/chrome/locale/fr/strings.properties
@@ -20,7 +20,7 @@ options_page__basic_usage=Utilisation de base
 options_page__changes_saved=Modifications sauvegardées
 options_page__click_toggle=Faites un clic droit dans le courriel puis sélectionnez \"Basculez vers Markdown\". (Ou cliquez sur le bouton <img src=\"images/icon16.png\"/> dans la barre d'outils.<span class=\"hotkey-display-wrapper\"> Ou appuyez sur <span class=\"hotkey-display\"><kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>M</kbd></span></span>)
 options_page__contributing_1=<strong>Si vous avez déjà mis un bloc de code dans un courriel, vous pouvez aider à améliorer Markdown Here.</strong> <a href=\"https://github.com/adam-p/markdown-here/blob/master/CONTRIBUTING.md\" target=\"_blank\"> CONTRIBUTING.md</a>
-options_page__contributing_2=Aidez à rendre Markdown Here disponible dans votre langue. <a href=\"https://github.com/adam-p/markdown-here/blob/master/CONTRIBUTING.md#translation\" target=\"_blank\">Les traducations sont les bienvenues.</a>
+options_page__contributing_2=Aidez à rendre Markdown Here disponible dans votre langue. <a href=\"https://github.com/adam-p/markdown-here/blob/master/CONTRIBUTING.md#translation\" target=\"_blank\">Les traductions sont les bienvenues.</a>
 options_page__contributing_title=Contribuer
 options_page__donate_plea_1=Si d'aventure vous estimez que Markdown Here est assez sympa, merci de m'aider à acheter des fleurs à ma femme pour qu'elle ne soit pas jalouse du temps que j'y consacre. <strong>Merci !</strong>
 options_page__donate_plea_2=<strong>Aidez à rendre Markdown Here meilleur!</strong>


### PR DESCRIPTION
This is a typo.