### PR TITLE
Add sponsorship button to Github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://paypal.me/adampritchard

--- a/contributors/mtlynch.md
+++ b/contributors/mtlynch.md
@@ -1,0 +1,9 @@
+2024-11-10
+
+I hereby agree to the terms of the "Markdown Here Individual Contributor License Agreement", with MD5 checksum dda72cea89d55de9fda0a102494134b4.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Michael Lynch https://github.com/mtlynch


### PR DESCRIPTION
Thanks for your excellent work on this tool!

I notice that the extension lists donation paths, but the project doesn't, so I thought I'd suggest a link. Adding this to Github allows you to create a "Sponsor" button on the repo, like this:

![image](https://github.com/user-attachments/assets/2d0000fd-931e-482c-87b8-63d3c98294dd)

I believe you need to flip on Sponsorships in the settings to enable the button to appear:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository