### PR TITLE
Update privacy policy to note data sharing with CodeCogs

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,4 +5,7 @@ The _Markdown Here_ browser extension strictly does one thing: Allows users to c
 This means that:
 - It collects no user or usage data.
 - It does not read or modify any part of any site besides the contents of the focused edit control, and only when the user tells it to do so.
-- It makes no external requests at all. All rendering is done locally.
+
+## What data is shared?
+
+- Markdown Here uses the third-party [CodeCogs](https://codecogs.com/) to render math equations. When you render markdown that contains mathematical equations, Markdown Here sends the mathematical portion of your markdown to CodeCogs for rendering.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,6 +6,6 @@ This means that:
 - It collects no user or usage data.
 - It does not read or modify any part of any site besides the contents of the focused edit control, and only when the user tells it to do so.
 
-## What data is shared?
+## What data does Markdown Here share?
 
 - Markdown Here uses the third-party [CodeCogs](https://codecogs.com/) to render math equations. When you render markdown that contains mathematical equations, Markdown Here sends the mathematical portion of your markdown to CodeCogs for rendering.


### PR DESCRIPTION
I noticed from https://github.com/adam-p/markdown-here/issues/874 that Markdown Here's privacy policy was out of date, so I took a pass at the policy language to disclose data sharing with CodeCogs for math rendering.