### PR TITLE
Remove references to the Markdown Here Google Group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing.md
 
 * Project page: https://github.com/adam-p/markdown-here
-* Google Group: https://groups.google.com/forum/#!forum/markdown-here
 * Website: https://markdown-here.com
 * Email me: pritchard.adam@gmail.com
 
@@ -17,7 +16,7 @@ When submitting a pull request for the first time, you will need to agree to the
 
 We use Crowdin for crowd-sourced translation. If you visit the [Markdown Here Crowdin project page](https://crowdin.net/project/markdown-here) you'll find that it's quite easy to contribute. Feel free to add new translations, improve existing ones, or even create new language categories.
 
-If you do make any translation changes, or if you have any questions or problems, please post to the MDH Google Group or create a Github issue. (I can't figure out a way to get notified when translations are updated, so you'll have to let me know that there are new ones to integrate.)
+If you do make any translation changes, or if you have any questions or problems, please create a Github issue. (I can't figure out a way to get notified when translations are updated, so you'll have to let me know that there are new ones to integrate.)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [**Get it for Safari.**](https://s3.amazonaws.com/markdown-here/markdown-here.safariextz)<br>
 [**Get it for Thunderbird and Postbox.**](https://addons.mozilla.org/en-US/thunderbird/addon/markdown-here/)<br>
 [**Get it for Opera.**](https://addons.opera.com/en/extensions/details/markdown-here/)<br>
-[**Discuss it and ask questions in the Google Group.**](https://groups.google.com/forum/?fromgroups#!forum/markdown-here/)<br>
 
 *Markdown Here* is a Google Chrome, Firefox, Safari, Opera, and Thunderbird extension that lets you write email<sup>&dagger;</sup> in Markdown<sup>&Dagger;</sup> and render them before sending. It also supports syntax highlighting (just specify the language in a fenced code block).
 
@@ -216,7 +215,7 @@ Use the Safari Extension Builder.
 
 See the [issues list](https://github.com/adam-p/markdown-here/issues) and the [Notes Wiki](https://github.com/adam-p/markdown-here/wiki/Development-Notes). All ideas, bugs, plans, complaints, and dreams will end up in one of those two places.
 
-Feel free to create a feature request issue if what you want isn't already there. If you'd prefer a less formal approach to floating an idea, post to the ["markdown-here" Google Group](https://groups.google.com/forum/?fromgroups=#!forum/markdown-here).
+Feel free to create a feature request issue if what you want isn't already there.
 
 It also takes a fair bit of work to stay up-to-date with the latest changes in all the applications and web sites where Markdown Here works.
 
@@ -230,7 +229,7 @@ It also takes a fair bit of work to stay up-to-date with the latest changes in a
 
 ## Feedback
 
-All bugs, feature requests, pull requests, feedback, etc., are welcome. [Create an issue](https://github.com/adam-p/markdown-here/issues). Or [post to the "markdown-here" Google Group](https://groups.google.com/forum/?fromgroups=#!forum/markdown-here).
+All bugs, feature requests, pull requests, feedback, etc., are welcome. [Create an issue](https://github.com/adam-p/markdown-here/issues).
 
 ## License
 

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -374,9 +374,6 @@ MIT License : https://adampritchard.mit-license.org/
           <li data-i18n="advanced_usage">
             For lots more info and advanced usage, see the <a href="https://github.com/adam-p/markdown-here" target="_blank">Markdown Here project page</a>. You should also explore the options below.
           </li>
-          <li data-i18n="ggroup">
-            Ask a question, start a discussion, or just say hi in the <a href="https://groups.google.com/forum/?fromgroups=#!forum/markdown-here" target="_blank">markdown-here Google Group</a>.
-          </li>
           <li data-i18n="mdh_wiki">
             Visit the <a href="https://github.com/adam-p/markdown-here/wiki" target="_blank">Markdown Here wiki</a> for info about <a href="https://github.com/adam-p/markdown-here/wiki/Compatibility" target="_blank">where else MDH works</a> and more <a href="https://github.com/adam-p/markdown-here/wiki/Tips-and-Tricks" target="_blank">tips and tricks</a>.
           </li>
@@ -659,7 +656,7 @@ MIT License : https://adampritchard.mit-license.org/
 
   <footer>
     <p data-i18n="footer_1">
-      <em>Markdown Here</em> is open source. To ask questions, report bugs, request features, or contribute, visit the <a target="_blank" href="https://github.com/adam-p/markdown-here">Github project page</a> or the <a target="_blank" href="https://groups.google.com/forum/?fromgroups=#!forum/markdown-here">"markdown-here" Google Group</a>.
+      <em>Markdown Here</em> is open source. To ask questions, report bugs, request features, or contribute, visit the <a target="_blank" href="https://github.com/adam-p/markdown-here">Github project page</a>.
     </p>
     <p data-i18n="footer_2">
       Created by <a target="_blank" href="https://adam-p.github.io/">Adam Pritchard</a>.


### PR DESCRIPTION
The group appears to have been permanently shut down, so this change removes links and references to the group.